### PR TITLE
Use Launcher instead of java -jar

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -23,7 +23,7 @@ cd ~
 echo "Sett env vars"
 export BROADWAY_DISPLAY=:5
 export GDK_BACKEND=broadway
-echo "Starting eclipse..."
-echo '*** Please connect to http://'`grep $HOSTNAME /etc/hosts | awk '{print $1}'`' using your web browser ***'
-java -jar /root/eclipse/plugins/org.eclipse.equinox.launcher_1.5.100.v20180827-1352.jar -data /projects
+echo "Starting Eclipse IDE..."
+echo '*** Please connect to http://'`grep $HOSTNAME /etc/hosts | awk '{print $1}'`':5000 using your web browser ***'
+/root/eclipse/eclipse -data /projects
 tail -f /dev/null


### PR DESCRIPTION
Using launcher is more portable and adds some extra sugar about JVM detection.