### PR TITLE
update eclipse broadway to 4.16 and java 11, add proxy configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,26 @@
-FROM fedora:31
-RUN dnf -y update && dnf -y install \
-      dbus dbus-daemon dbus-glib \
-      xorg-x11-server-utils \
-      webkit2gtk3 webkit2gtk3-devel \
-      mesa-libGL \
-      adobe-source-code-pro-fonts abattis-cantarell-fonts \
-      gnome-settings-daemon \
-      wget tar \
-      java-11-openjdk \
-      && dnf clean all
+ARG HTTP_PROXY=http://proxyserver:3128/
 
-# Build gtk from source to get patch for https://gitlab.gnome.org/GNOME/gtk/issues/2119 (not yet in Fedora 31)
-# Once recent enough version of GTK is available in Fedora, replace all that by just adding `gtk3` to above dnf command
-RUN dnf -y update && dnf -y install \
-      gtk-doc cairo-gobject-devel libepoxy-devel atk-devel at-spi2-atk-devel gobject-introspection-devel \
-      gettext-devel pango-devel fribidi-devel gdk-pixbuf2-devel file make diffutils patch \
-      && dnf clean all
-COPY gtk_broadway_selection.issue1630.patch /root
-RUN cd /root && \
-	wget -O- https://gitlab.gnome.org/GNOME/gtk/-/archive/gtk-3-24/gtk-gtk-3-24.tar.gz | tar xz && \
-	cd gtk-gtk-3-24 && \
-	patch -p1 -i /root/gtk_broadway_selection.issue1630.patch && \
-	./autogen.sh --enable-broadway-backend --enable-x11-backend --enable-introspection --disable-gtk-docs --disable-cups --disable-xinerama --disable-xkb --prefix=/opt/gtk && \
-	./configure --enable-broadway-backend --enable-x11-backend --enable-introspection --disable-gtk-docs --disable-cups --disable-xinerama --disable-xkb --prefix=/opt/gtk && \
-	make && \
-	make install && \
-	cp -rf /opt/gtk/share/glib-2.0/schemas/* /usr/share/glib-2.0/schemas/ && \
-	cd .. && \
-	rm -r gtk-gtk-3-24 
-RUN dnf -y remove \
-      gtk-doc cairo-gobject-devel libepoxy-devel atk-devel at-spi2-atk-devel gobject-introspection-devel \
-      gettext-devel pango-devel fribidi-devel gdk-pixbuf2-devel file make diffutils \
-      && dnf clean all
-ENV LD_LIBRARY_PATH=/opt/gtk/lib
-ENV PATH="/opt/gtk/bin:$PATH"
+FROM openjdk:11
+ARG HTTP_PROXY
+
+# Configure apt proxy
+RUN if [ -n "${HTTP_PROXY}" ]; then \
+        echo "Acquire::http::No-Cache True;\
+            \nAcquire::https::No-Cache True;\
+            \nAcquire::http::Pipeline-Depth 0;\
+            \nAcquire::http::Timeout 30;\
+            \nAcquire::BrokenProxy True;" > /etc/apt/apt.conf; \
+        echo "Acquire::http::Proxy \"${HTTP_PROXY}\";" >> /etc/apt/apt.conf; \
+        echo "Acquire::https::Proxy \"${HTTP_PROXY}\";" >> /etc/apt/apt.conf; \
+        cat /etc/apt/apt.conf; \
+    fi
+
+# Install base packages, Webkit for GTK-3 / OpenGL libs / + utilities
+RUN apt-get update && apt-get install -y \
+    curl apt-transport-https debconf-utils \
+    mesa-utils libgl1-mesa-glx libgl1-mesa-dri \
+    nano \
+    sshpass
 
 # Configure broadway
 ENV BROADWAY_DISPLAY=:5
@@ -44,11 +31,11 @@ ENV GDK_BACKEND=broadway
 # Get Eclipse IDE
 RUN echo "Downloading Eclipse" && \
     cd /root && \
-    wget -O- "http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/2019-09/R/eclipse-java-2019-09-R-linux-gtk-x86_64.tar.gz" | tar xz && \
+    curl -x ${HTTP_PROXY} "http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/2020-06/M3/eclipse-java-2020-06-M3-linux-gtk-x86_64.tar.gz" | tar xz && \
     cd eclipse/ && \
     echo $'name=Eclipse IDE\n\
 id=org.eclipse.ui.ide.workbench\n\
-version=4.13.0' > .eclipseproduct
+version=4.16.0' > .eclipseproduct
 
 # Prepare project area
 RUN mkdir /projects


### PR DESCRIPTION
I added a proxy configuration and upgraded to java 11 - with the other changes i am not sure. Hope it is possible to use a different image as i have done it. I can build the Docker image but have an issue with access to my local docker registry so cannot test. Would be cool if there would be a recent version available for demo purposes.